### PR TITLE
Add 10 and 20Mhz ftdi speeds, tested with Saleae logic

### DIFF
--- a/src/spi.rs
+++ b/src/spi.rs
@@ -15,6 +15,8 @@ pub enum SpiSpeed {
     CLK_1MHz,
     CLK_3MHz,
     CLK_5MHz,
+    CLK_10MHz,
+    CLK_20MHz,
 }
 
 pub struct SpiBus<'a> {

--- a/src/x232h.rs
+++ b/src/x232h.rs
@@ -153,6 +153,8 @@ impl FTx232H {
                 SpiSpeed::CLK_1MHz | SpiSpeed::CLK_AUTO => (0x1d, 0x0),
                 SpiSpeed::CLK_3MHz => (0x9, 0x0),
                 SpiSpeed::CLK_5MHz => (0x5, 0x0),
+                SpiSpeed::CLK_10MHz => (0x2, 0x0),
+                SpiSpeed::CLK_20MHz => (0x1, 0x0),
             };
 
             ftdi.write_all(&[MPSSECmd::TCK_DIVISOR.into(), div1, div2])?;


### PR DESCRIPTION
I am using this to control a 64*64 RGB LED matrix, and I needed a bit more speed to get data over quick enough. 
I added a 10Mhz and 20Mhz speed option for SPI, both options have been tested and work as expected (verified speed using a logic analyzer, transferred several GBs of data)